### PR TITLE
Filter query param should not be required

### DIFF
--- a/shared/payload.go
+++ b/shared/payload.go
@@ -236,10 +236,6 @@ func (sr SearchRequest) Validate(guide AttributeSource) error {
 		return Error.InvalidParam("search request", "search operation urn", "non-search urn")
 	}
 
-	if len(sr.Filter) == 0 {
-		return Error.InvalidParam("search request", "query string", "empty string")
-	}
-
 	if sr.StartIndex < 1 {
 		sr.StartIndex = 1
 	}


### PR DESCRIPTION
* According to spec filter should not be required, Okta is sending a test query without it. - https://tools.ietf.org/html/rfc7644#section-3.4.1